### PR TITLE
fix creating a pipeline with inputs from more than one device

### DIFF
--- a/src/app/modules/data/flow-repo/deploy-flow/deploy-flow.component.ts
+++ b/src/app/modules/data/flow-repo/deploy-flow/deploy-flow.component.ts
@@ -123,11 +123,21 @@ export class DeployFlowComponent {
                             node.inputs = [];
                         }
                         if (node.inputs.length > 0) {
+                            let inserted = false;
+                            let counter = 0;
+                            const length = node.inputs.length;
+                            // Try to add current entry to existing input
                             node.inputs.forEach((input: NodeInput) => {
+                                counter++;
                                 if (input.deviceId === entry[1].device.id) {
                                     if (input.values.length > 0) {
                                         input.values.push(x);
+                                        inserted = true;
                                     }
+                                }
+                                if (counter === length && inserted === false && node.inputs) {
+                                    // No existing input found for device ID, create new input
+                                    node.inputs.push(z);
                                 }
                             });
                         } else {


### PR DESCRIPTION
Currently when deploying a pipeline with entries from more than one device the configuration will miss entries from the other devices and will only contain entries for the first device.

This is fixed by checking if we were able to insert entries to an existing input and, if not, creating a new input.